### PR TITLE
Fix Layout Editor errors

### DIFF
--- a/library/src/main/java/jp/yokomark/widget/account/autocomp/AccountAutoCompleteEditText.java
+++ b/library/src/main/java/jp/yokomark/widget/account/autocomp/AccountAutoCompleteEditText.java
@@ -50,6 +50,7 @@ public class AccountAutoCompleteEditText extends AutoCompleteTextView {
     protected void onFinishInflate() {
         super.onFinishInflate();
 
+        if (isInEditMode()) return;
         ArrayAdapter<String> adapter = new ArrayAdapter<String>(
                 getContext(), android.R.layout.simple_dropdown_item_1line, CandidateCollector
                 .getAccounts(getContext(), mAccountType));


### PR DESCRIPTION
Layout Editor crashes when the lib tries to access the AccountManager to retrieve accounts saved on the device.
